### PR TITLE
Fix symlink check and update Python module versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ packages = ["webapps_manager"]
 package-dir = {webapps_manager = "src"}
 include-package-data = true
 
+[tool.setuptools.dynamic]
+version = {attr = "webapps_manager.version.APP_VERSION"}
 
 [tool.setuptools.data-files]
 

--- a/src/browser.py
+++ b/src/browser.py
@@ -24,7 +24,7 @@ class Browser:
         self.exec_path = exec_path
         self.test_path = test_path
         self.icon = icon
-        self.exists = os.path.exists(test_path)
+        self.exists = os.path.exists(test_path) or os.path.islink(test_path)
 
 SUPPORTED_BROWSERS = [Browser(BrowserType.BROWSER_TYPE_FIREFOX, "Firefox", "firefox", f"{OS_BIN}/firefox", "firefox"),
                 Browser(BrowserType.BROWSER_TYPE_FIREFOX, "Firefox Developer Edition", "firefox-developer-edition", f"{OS_BIN}/firefox-developer-edition", "firefox-developer-edition"),


### PR DESCRIPTION
Enhance the symlink check in the browser class to account for symbolic links and update the versioning method for the Python module in the project configuration.